### PR TITLE
Remove commented-out section from page

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,22 +71,6 @@
             </p>
             <button ng-disabled="form.$invalid">Report</button>
           </form>
-
-          <!--
-          <h2>FAQs</h2>
-          <h3>What counts as a CoC violation?</h3>
-          <p>We follow the <a href="">JSConf CoC</a>. Examples include, but aren't limited to: </p>
-          <ul>
-            <li>Sexually suggestive remarks made toward other attendees.</li>
-            <li>Another example.</li>
-            <li>Another example.</li>
-          </ul>
-          <h3>If someone's actions are making me feel uncomfortable, am I being too sensitive?</h3>
-          <p>Probably not. If someone's making you feel that way, chance are other people are feeling the same thing.</p>
-          <h3>What will happen after I report an incident?</h3>
-          <p>Description goes here.</p>
-          <p>If you let us know who you are, we'll ask you what you'd like happen. We'll do our best to accommodate your request.</p>
-          -->
         </div>
       </section>
     </main>


### PR DESCRIPTION
We might not want to include this in the page since it's commented out. We can always revive it from the git history if desired.